### PR TITLE
update dependencies management instruction in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,4 +23,4 @@ Follow either of the two links above to access the appropriate CLA and instructi
 
 ### Adding dependencies
 
-If your patch depends on new packages, add that package with [`godep`](https://github.com/tools/godep). Follow the [instructions to add a dependency](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md#godep-and-dependency-management).
+The project follows a standard Go project layout, see more about [dependency-management](https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#dependency-management).


### PR DESCRIPTION
Signed-off-by: Dominic Yin <yindongchao@inspur.com>

Updated dependencies instruction in CONTRIBUTING.md:

1. The dependency management tool has changed from `go dep` to `go module`.
2. Kubernetes documents has moved to new repository, so the link should be updated. See https://github.com/kubernetes/kubernetes/pull/39120