### PR TITLE
Fixed format of go.mod file for go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-incubator/custom-metrics-apiserver
 
-go 1.13.6
+go 1.13
 
 require (
 	github.com/emicklei/go-restful v2.9.5+incompatible


### PR DESCRIPTION
The go version direction in the `go.mod` file should not contain the minor version number. It specifies a format associated with one version of _go_ and does not change with minor versions. If specified this project cannot be used as a dependency because it gives the following error:

```
go: github.com/kubernetes-incubator/custom-metrics-apiserver@v0.0.0-20200318092248-e409b1073fa9: parsing go.mod: go.mod:3: usage: go 1.23
```