### PR TITLE
chore: use sigs.k8s.io instead of github.com/kubernetes-sigs to refer go pkgs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: build-test-adapter
 
 .PHONY: build-test-adapter
 build-test-adapter: test-adapter/generated/openapi/zz_generated.openapi.go
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -o $(OUT_DIR)/$(ARCH)/test-adapter github.com/kubernetes-sigs/custom-metrics-apiserver/test-adapter
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -o $(OUT_DIR)/$(ARCH)/test-adapter sigs.k8s.io/custom-metrics-apiserver/test-adapter
 
 test-adapter/generated/openapi/zz_generated.openapi.go: go.mod go.sum
 	go install -mod=readonly k8s.io/kube-openapi/cmd/openapi-gen

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,7 +60,7 @@ import (
     "k8s.io/client-go/dynamic"
     "k8s.io/metrics/pkg/apis/custom_metrics"
 
-    "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
+    "sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
     "k8s.io/metrics/pkg/apis/external_metrics"
 )
 ```
@@ -315,8 +315,8 @@ import (
     "k8s.io/apimachinery/pkg/util/wait"
     "k8s.io/component-base/logs"
 
-    basecmd "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/cmd"
-    "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
+    basecmd "sigs.k8s.io/custom-metrics-apiserver/pkg/cmd"
+    "sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 
     // make this the path to the provider that you just wrote
     yourprov "github.com/user/repo/pkg/provider"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubernetes-sigs/custom-metrics-apiserver
+module sigs.k8s.io/custom-metrics-apiserver
 
 go 1.16
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -25,10 +25,10 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/informers"
 
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/apiserver/installer"
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
 	cminstall "k8s.io/metrics/pkg/apis/custom_metrics/install"
 	eminstall "k8s.io/metrics/pkg/apis/external_metrics/install"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/installer"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 )
 
 var (

--- a/pkg/apiserver/cmapis.go
+++ b/pkg/apiserver/cmapis.go
@@ -25,10 +25,10 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/discovery"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 
-	specificapi "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/apiserver/installer"
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
-	metricstorage "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/registry/custom_metrics"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
+	specificapi "sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/installer"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+	metricstorage "sigs.k8s.io/custom-metrics-apiserver/pkg/registry/custom_metrics"
 )
 
 func (s *CustomMetricsAdapterServer) InstallCustomMetricsAPI() error {

--- a/pkg/apiserver/emapis.go
+++ b/pkg/apiserver/emapis.go
@@ -25,10 +25,10 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/discovery"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 
-	specificapi "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/apiserver/installer"
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
-	metricstorage "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/registry/external_metrics"
 	"k8s.io/metrics/pkg/apis/external_metrics"
+	specificapi "sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/installer"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+	metricstorage "sigs.k8s.io/custom-metrics-apiserver/pkg/registry/external_metrics"
 )
 
 // InstallExternalMetricsAPI registers the api server in Kube Aggregator

--- a/pkg/apiserver/endpoints/handlers/get.go
+++ b/pkg/apiserver/endpoints/handlers/get.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 	utiltrace "k8s.io/utils/trace"
 
-	cm_rest "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/apiserver/registry/rest"
+	cm_rest "sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/registry/rest"
 )
 
 func ListResourceWithOptions(r cm_rest.ListerWithOptions, scope handlers.RequestScope) http.HandlerFunc {

--- a/pkg/apiserver/installer/apiserver_test.go
+++ b/pkg/apiserver/installer/apiserver_test.go
@@ -41,11 +41,11 @@ import (
 	installem "k8s.io/metrics/pkg/apis/external_metrics/install"
 	emv1beta1 "k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
 
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
-	custommetricstorage "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/registry/custom_metrics"
-	externalmetricstorage "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/registry/external_metrics"
-	sampleprovider "github.com/kubernetes-sigs/custom-metrics-apiserver/test-adapter/provider"
 	"k8s.io/metrics/pkg/apis/external_metrics"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+	custommetricstorage "sigs.k8s.io/custom-metrics-apiserver/pkg/registry/custom_metrics"
+	externalmetricstorage "sigs.k8s.io/custom-metrics-apiserver/pkg/registry/external_metrics"
+	sampleprovider "sigs.k8s.io/custom-metrics-apiserver/test-adapter/provider"
 )
 
 // defaultAPIServer exposes nested objects for testability.

--- a/pkg/apiserver/installer/cmhandlers.go
+++ b/pkg/apiserver/installer/cmhandlers.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/metrics"
 
 	"github.com/emicklei/go-restful"
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/apiserver/registry/rest"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/registry/rest"
 )
 
 type CMHandlers struct{}

--- a/pkg/apiserver/installer/installer.go
+++ b/pkg/apiserver/installer/installer.go
@@ -35,8 +35,8 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	"github.com/emicklei/go-restful"
-	cm_handlers "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/apiserver/endpoints/handlers"
-	cm_rest "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/apiserver/registry/rest"
+	cm_handlers "sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/endpoints/handlers"
+	cm_rest "sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/registry/rest"
 )
 
 // NB: the contents of this file should mostly be a subset of the functionality

--- a/pkg/cmd/builder.go
+++ b/pkg/cmd/builder.go
@@ -31,10 +31,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
 
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/apiserver"
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/cmd/server"
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/dynamicmapper"
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/cmd/server"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/dynamicmapper"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 )
 
 // AdapterBase provides a base set of functionality for any custom metrics adapter.

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -24,7 +24,7 @@ import (
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
 
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/apiserver"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver"
 )
 
 type CustomMetricsAdapterServerOptions struct {

--- a/pkg/provider/helpers/helpers.go
+++ b/pkg/provider/helpers/helpers.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 )
 
 // ResourceFor attempts to resolve a single qualified resource for the given metric.

--- a/pkg/registry/custom_metrics/reststorage.go
+++ b/pkg/registry/custom_metrics/reststorage.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	cm_rest "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/apiserver/registry/rest"
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
+	cm_rest "sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/registry/rest"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/registry/external_metrics/reststorage.go
+++ b/pkg/registry/external_metrics/reststorage.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,6 +27,7 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/metrics/pkg/apis/external_metrics"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 )
 
 // REST is a wrapper for CustomMetricsProvider that provides implementation for Storage and Lister

--- a/test-adapter/main.go
+++ b/test-adapter/main.go
@@ -29,11 +29,11 @@ import (
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/apiserver"
-	basecmd "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/cmd"
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
-	generatedopenapi "github.com/kubernetes-sigs/custom-metrics-apiserver/test-adapter/generated/openapi"
-	fakeprov "github.com/kubernetes-sigs/custom-metrics-apiserver/test-adapter/provider"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver"
+	basecmd "sigs.k8s.io/custom-metrics-apiserver/pkg/cmd"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+	generatedopenapi "sigs.k8s.io/custom-metrics-apiserver/test-adapter/generated/openapi"
+	fakeprov "sigs.k8s.io/custom-metrics-apiserver/test-adapter/provider"
 )
 
 type SampleAdapter struct {

--- a/test-adapter/provider/provider.go
+++ b/test-adapter/provider/provider.go
@@ -35,8 +35,8 @@ import (
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider/helpers"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider/helpers"
 )
 
 // CustomMetricResource wraps provider.CustomMetricInfo in a struct which stores the Name and Namespace of the resource


### PR DESCRIPTION
Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>