### PR TITLE
Allow users to configure audit logs

### DIFF
--- a/pkg/cmd/builder.go
+++ b/pkg/cmd/builder.go
@@ -98,6 +98,7 @@ func (b *AdapterBase) InstallFlags() {
 		b.SecureServing.AddFlags(b.FlagSet)
 		b.Authentication.AddFlags(b.FlagSet)
 		b.Authorization.AddFlags(b.FlagSet)
+		b.Audit.AddFlags(b.FlagSet)
 		b.Features.AddFlags(b.FlagSet)
 
 		b.FlagSet.StringVar(&b.RemoteKubeConfigFile, "lister-kubeconfig", b.RemoteKubeConfigFile,

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -32,6 +32,7 @@ type CustomMetricsAdapterServerOptions struct {
 	SecureServing  *genericoptions.SecureServingOptionsWithLoopback
 	Authentication *genericoptions.DelegatingAuthenticationOptions
 	Authorization  *genericoptions.DelegatingAuthorizationOptions
+	Audit          *genericoptions.AuditOptions
 	Features       *genericoptions.FeatureOptions
 
 	// OpenAPIConfig
@@ -43,6 +44,7 @@ func NewCustomMetricsAdapterServerOptions() *CustomMetricsAdapterServerOptions {
 		SecureServing:  genericoptions.NewSecureServingOptions().WithLoopback(),
 		Authentication: genericoptions.NewDelegatingAuthenticationOptions(),
 		Authorization:  genericoptions.NewDelegatingAuthorizationOptions(),
+		Audit:          genericoptions.NewAuditOptions(),
 		Features:       genericoptions.NewFeatureOptions(),
 	}
 
@@ -72,6 +74,10 @@ func (o CustomMetricsAdapterServerOptions) Config() (*apiserver.Config, error) {
 		return nil, err
 	}
 	if err := o.Authorization.ApplyTo(&serverConfig.Authorization); err != nil {
+		return nil, err
+	}
+
+	if err := o.Audit.ApplyTo(serverConfig); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Audit logs can be very helpful when debugging requests coming to the
metrics server. They provide insights on the requested resources as well
are information on the user that sent the requests. This is helpful when
trying to narrow down applications spamming the server. Also, we can
configure the audit logs to provide even more information such as the
content of the response which is very helpful when trying to introspect
incorrect data.

/cc @s-urbaniak @fpetkovski