### PR TITLE
Fix kubectl proxy port from 8080 to 8001

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ kubectl proxy &
 # write a sample metric -- the write paths match the same URL structure
 # as the read paths, but at the /write-metrics base path.
 # data needs to be in json, so we also need to set the content-type header
-curl -XPOST -H 'Content-Type: application/json' http://localhost:8080/api/v1/namespaces/custom-metrics/services/custom-metrics-apiserver:http/proxy/write-metrics/namespaces/default/services/kubernetes/test-metric --data-raw '"300m"'
+curl -XPOST -H 'Content-Type: application/json' http://localhost:8001/api/v1/namespaces/custom-metrics/services/custom-metrics-apiserver:http/proxy/write-metrics/namespaces/default/services/kubernetes/test-metric --data-raw '"300m"'
 ```
 
 ```


### PR DESCRIPTION
This pr is used to fix  kubectl proxy port from 8080 to 8001 in README.md