### PR TITLE
Update and fix Getting Started guide

### DIFF
--- a/test-adapter-deploy/README.md
+++ b/test-adapter-deploy/README.md
@@ -2,6 +2,6 @@
 
 These files can be used to deploy the sample adapter container.  You can
 build that with `make test-adapter-container`.  The Dockerfile describes the
-container itself, while the [manifests](manifests) can be used to deploy
-that container as a provider of the custom metrics and external metrics
-APIs on the cluster.
+container itself, while the [manifest](./testing-adapter.yaml) can be used
+to deploy that container as a provider of the custom metrics and external
+metrics APIs on the cluster.


### PR DESCRIPTION
This PR updates the Getting Started guide, in particular:
- use up-to-date metric API interfaces
- fix naming consistence