### PR TITLE
test-adapter: refactor adding logging flags

### DIFF
--- a/test-adapter-deploy/Dockerfile
+++ b/test-adapter-deploy/Dockerfile
@@ -1,3 +1,3 @@
 FROM BASEIMAGE
 COPY adapter /
-ENTRYPOINT ["/adapter", "--logtostderr=true"]
+ENTRYPOINT ["/adapter"]

--- a/test-adapter-deploy/testing-adapter.yaml
+++ b/test-adapter-deploy/testing-adapter.yaml
@@ -56,7 +56,6 @@ spec:
         args:
         - /adapter
         - --secure-port=6443
-        - --logtostderr=true
         - --v=10
         ports:
         - containerPort: 6443

--- a/test-adapter/main.go
+++ b/test-adapter/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"net/http"
 	"os"
 	"time"
@@ -56,13 +55,12 @@ func (a *SampleAdapter) makeProviderOrDie() (provider.MetricsProvider, *restful.
 func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
-	klog.InitFlags(nil)
 
 	cmd := &SampleAdapter{}
 	cmd.Name = "test-adapter"
 
 	cmd.Flags().StringVar(&cmd.Message, "msg", "starting adapter...", "startup message")
-	cmd.Flags().AddGoFlagSet(flag.CommandLine) // make sure we get the klog flags
+	logs.AddFlags(cmd.Flags())
 	if err := cmd.Flags().Parse(os.Args); err != nil {
 		klog.Fatalf("unable to parse flags: %v", err)
 	}


### PR DESCRIPTION
Instead of using `klog.InitFlags()` to add logging flags to Go `flags.FlagSet`, then adding them to `github.com/spf13/pflag.FlagSet`, we directly add them to `github.com/spf13/pflag.FlagSet`.

Also, remove deprecated flag `--logtostderr=true` from test-adapter's Dockerfile and manifest.
The flag is still accepted, but [is deprecated and will soon be removed](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components); as `true` is its default value, removing the flag from the manifest does not break things.

/kind cleanup
