### PR TITLE
Add metric about metrics freshness

### DIFF
--- a/pkg/apiserver/metrics/metrics.go
+++ b/pkg/apiserver/metrics/metrics.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package metrics provides metrics and instrumentation functions for the
+// metrics API server.
+package metrics
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/metrics"
+	"k8s.io/utils/clock"
+)
+
+var (
+	metricFreshness = metrics.NewHistogramVec(&metrics.HistogramOpts{
+		Namespace:      "metrics_apiserver",
+		Name:           "metric_freshness_seconds",
+		Help:           "Freshness of metrics exported",
+		StabilityLevel: metrics.ALPHA,
+		Buckets:        metrics.ExponentialBuckets(1, 1.364, 20),
+	}, []string{"group"})
+)
+
+// RegisterMetrics registers API server metrics, given a registration function.
+func RegisterMetrics(registrationFunc func(metrics.Registerable) error) error {
+	return registrationFunc(metricFreshness)
+}
+
+// FreshnessObserver captures individual observations of the timestamp of
+// metrics.
+type FreshnessObserver interface {
+	Observe(timestamp metav1.Time)
+}
+
+// NewFreshnessObserver creates a FreshnessObserver for a given metrics API group.
+func NewFreshnessObserver(apiGroup string) FreshnessObserver {
+	return &freshnessObserver{
+		apiGroup: apiGroup,
+		clock:    clock.RealClock{},
+	}
+}
+
+type freshnessObserver struct {
+	apiGroup string
+	clock    clock.PassiveClock
+}
+
+func (o *freshnessObserver) Observe(timestamp metav1.Time) {
+	metricFreshness.WithLabelValues(o.apiGroup).
+		Observe(o.clock.Since(timestamp.Time).Seconds())
+}

--- a/pkg/apiserver/metrics/metrics_test.go
+++ b/pkg/apiserver/metrics/metrics_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/metrics/testutil"
+	"k8s.io/metrics/pkg/apis/custom_metrics"
+	"k8s.io/metrics/pkg/apis/external_metrics"
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+func TestFreshness(t *testing.T) {
+	now := time.Now()
+
+	metricFreshness.Create(nil)
+	metricFreshness.Reset()
+
+	externalMetricsList := external_metrics.ExternalMetricValueList{
+		Items: []external_metrics.ExternalMetricValue{
+			{Timestamp: metav1.NewTime(now.Add(-10 * time.Second))},
+			{Timestamp: metav1.NewTime(now.Add(-10 * time.Second))},
+			{Timestamp: metav1.NewTime(now.Add(-2 * time.Second))},
+		},
+	}
+	externalObserver := NewFreshnessObserver("external.metrics.k8s.io")
+	externalObserver.(*freshnessObserver).clock = clocktesting.NewFakeClock(now)
+	for _, m := range externalMetricsList.Items {
+		externalObserver.Observe(m.Timestamp)
+	}
+
+	customMetricsList := custom_metrics.MetricValueList{
+		Items: []custom_metrics.MetricValue{
+			{Timestamp: metav1.NewTime(now.Add(-5 * time.Second))},
+			{Timestamp: metav1.NewTime(now.Add(-10 * time.Second))},
+			{Timestamp: metav1.NewTime(now.Add(-25 * time.Second))},
+		},
+	}
+	customObserver := NewFreshnessObserver("custom.metrics.k8s.io")
+	customObserver.(*freshnessObserver).clock = clocktesting.NewFakeClock(now)
+	for _, m := range customMetricsList.Items {
+		customObserver.Observe(m.Timestamp)
+	}
+
+	err := testutil.CollectAndCompare(metricFreshness, strings.NewReader(`
+	# HELP metrics_apiserver_metric_freshness_seconds [ALPHA] Freshness of metrics exported
+	# TYPE metrics_apiserver_metric_freshness_seconds histogram
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="1"} 0
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="1.364"} 0
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="1.8604960000000004"} 0
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="2.5377165440000007"} 0
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="3.4614453660160014"} 0
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="4.721411479245826"} 0
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="6.440005257691307"} 1
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="8.784167171490942"} 1
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="11.981604021913647"} 2
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="16.342907885890217"} 2
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="22.291726356354257"} 2
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="30.405914750067208"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="41.47366771909167"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="56.57008276884105"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="77.16159289669919"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="105.2484127110977"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="143.55883493793726"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="195.81425085534644"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="267.09063816669254"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="364.31163045936864"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="custom.metrics.k8s.io",le="+Inf"} 3
+	metrics_apiserver_metric_freshness_seconds_sum{group="custom.metrics.k8s.io"} 40
+	metrics_apiserver_metric_freshness_seconds_count{group="custom.metrics.k8s.io"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="1"} 0
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="1.364"} 0
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="1.8604960000000004"} 0
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="2.5377165440000007"} 1
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="3.4614453660160014"} 1
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="4.721411479245826"} 1
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="6.440005257691307"} 1
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="8.784167171490942"} 1
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="11.981604021913647"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="16.342907885890217"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="22.291726356354257"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="30.405914750067208"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="41.47366771909167"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="56.57008276884105"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="77.16159289669919"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="105.2484127110977"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="143.55883493793726"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="195.81425085534644"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="267.09063816669254"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="364.31163045936864"} 3
+	metrics_apiserver_metric_freshness_seconds_bucket{group="external.metrics.k8s.io",le="+Inf"} 3
+	metrics_apiserver_metric_freshness_seconds_sum{group="external.metrics.k8s.io"} 22
+	metrics_apiserver_metric_freshness_seconds_count{group="external.metrics.k8s.io"} 3
+	`))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/pkg/registry/custom_metrics/reststorage.go
+++ b/pkg/registry/custom_metrics/reststorage.go
@@ -30,20 +30,24 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/metrics"
 	cm_rest "sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/registry/rest"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 )
 
 type REST struct {
-	cmProvider provider.CustomMetricsProvider
+	cmProvider        provider.CustomMetricsProvider
+	freshnessObserver metrics.FreshnessObserver
 }
 
 var _ rest.Storage = &REST{}
 var _ cm_rest.ListerWithOptions = &REST{}
 
 func NewREST(cmProvider provider.CustomMetricsProvider) *REST {
+	freshnessObserver := metrics.NewFreshnessObserver(custom_metrics.GroupName)
 	return &REST{
-		cmProvider: cmProvider,
+		cmProvider:        cmProvider,
+		freshnessObserver: freshnessObserver,
 	}
 }
 
@@ -118,11 +122,25 @@ func (r *REST) List(ctx context.Context, options *metainternalversion.ListOption
 		namespace = ""
 	}
 
+	var res *custom_metrics.MetricValueList
+	var err error
+
 	// handle namespaced and root metrics
 	if name == "*" {
-		return r.handleWildcardOp(ctx, namespace, groupResource, selector, metricName, metricLabelSelector)
+		res, err = r.handleWildcardOp(ctx, namespace, groupResource, selector, metricName, metricLabelSelector)
+	} else {
+		res, err = r.handleIndividualOp(ctx, namespace, groupResource, name, metricName, metricLabelSelector)
 	}
-	return r.handleIndividualOp(ctx, namespace, groupResource, name, metricName, metricLabelSelector)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, m := range res.Items {
+		r.freshnessObserver.Observe(m.Timestamp)
+	}
+
+	return res, nil
 }
 
 func (r *REST) handleIndividualOp(ctx context.Context, namespace string, groupResource schema.GroupResource, name string, metricName string, metricLabelSelector labels.Selector) (*custom_metrics.MetricValueList, error) {

--- a/pkg/registry/external_metrics/reststorage.go
+++ b/pkg/registry/external_metrics/reststorage.go
@@ -28,13 +28,15 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/metrics"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 )
 
 // REST is a wrapper for CustomMetricsProvider that provides implementation for Storage and Lister
 // interfaces.
 type REST struct {
-	emProvider provider.ExternalMetricsProvider
+	emProvider        provider.ExternalMetricsProvider
+	freshnessObserver metrics.FreshnessObserver
 	rest.TableConvertor
 }
 
@@ -43,8 +45,10 @@ var _ rest.Lister = &REST{}
 
 // NewREST returns new REST object for provided CustomMetricsProvider.
 func NewREST(emProvider provider.ExternalMetricsProvider) *REST {
+	freshnessObserver := metrics.NewFreshnessObserver(external_metrics.GroupName)
 	return &REST{
-		emProvider: emProvider,
+		emProvider:        emProvider,
+		freshnessObserver: freshnessObserver,
 	}
 }
 
@@ -81,5 +85,14 @@ func (r *REST) List(ctx context.Context, options *metainternalversion.ListOption
 	}
 	metricName := requestInfo.Resource
 
-	return r.emProvider.GetExternalMetric(ctx, namespace, metricSelector, provider.ExternalMetricInfo{Metric: metricName})
+	res, err := r.emProvider.GetExternalMetric(ctx, namespace, metricSelector, provider.ExternalMetricInfo{Metric: metricName})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, m := range res.Items {
+		r.freshnessObserver.Observe(m.Timestamp)
+	}
+
+	return res, nil
 }

--- a/test-adapter/main.go
+++ b/test-adapter/main.go
@@ -25,8 +25,10 @@ import (
 	"github.com/emicklei/go-restful/v3"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/component-base/logs"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/metrics"
 	basecmd "sigs.k8s.io/custom-metrics-apiserver/pkg/cmd"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 	fakeprov "sigs.k8s.io/custom-metrics-apiserver/test-adapter/provider"
@@ -70,6 +72,10 @@ func main() {
 	testProvider, webService := cmd.makeProviderOrDie()
 	cmd.WithCustomMetrics(testProvider)
 	cmd.WithExternalMetrics(testProvider)
+
+	if err := metrics.RegisterMetrics(legacyregistry.Register); err != nil {
+		klog.Fatal("unable to register metrics: %v", err)
+	}
 
 	klog.Infof(cmd.Message)
 	// Set up POST endpoint for writing fake metric values


### PR DESCRIPTION
Add a metric `custom_metrics_apiserver_metric_freshness_seconds`, similar to the [metric `metrics_server_api_metric_freshness_seconds` from metrics-server](https://github.com/kubernetes-sigs/metrics-server/blob/a8299de9be086b0cf787ba2c713d117c2f82b5d0/pkg/api/monitoring.go#L22-L30).

This metric can optionally be registered using `RegisterMetrics(registrationFunc func(metrics.Registerable) error) error`, e.g:

```go
metrics.RegisterMetrics(legacyregistry.Register)
```

Also, in test-adapter:
- register the new metric `custom_metrics_apiserver_metric_freshness_seconds`;
- currently, the timestamp for custom metrics values is the time when the metric is queried. With this change, the timestamp used is the time when the metric value is created / updated.

