### PR TITLE
Remove duplicated import

### DIFF
--- a/pkg/registry/custom_metrics/reststorage.go
+++ b/pkg/registry/custom_metrics/reststorage.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 
@@ -97,7 +96,7 @@ func (r *REST) List(ctx context.Context, options *metainternalversion.ListOption
 		}
 	}
 
-	namespace := genericapirequest.NamespaceValue(ctx)
+	namespace := request.NamespaceValue(ctx)
 
 	requestInfo, ok := request.RequestInfoFrom(ctx)
 	if !ok {

--- a/pkg/registry/external_metrics/reststorage.go
+++ b/pkg/registry/external_metrics/reststorage.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -73,7 +72,7 @@ func (r *REST) List(ctx context.Context, options *metainternalversion.ListOption
 		metricSelector = options.LabelSelector
 	}
 
-	namespace := genericapirequest.NamespaceValue(ctx)
+	namespace := request.NamespaceValue(ctx)
 
 	requestInfo, ok := request.RequestInfoFrom(ctx)
 	if !ok {


### PR DESCRIPTION
In two files, package `k8s.io/apiserver/pkg/endpoints/request` was imported twice (both as `request` and `genericapirequest`).

That was surprisingly not reported by golangci-lint.

/kind cleanup
