### PR TITLE
golangci-lint: add stylecheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - nolintlint
     - revive
     - staticcheck
+    - stylecheck
     - typecheck
     - unconvert
     - unused


### PR DESCRIPTION
Adding `stylecheck` linter, as it would have prevented duplicated import (#127).

This was prompted by this [comment](https://github.com/kubernetes-sigs/custom-metrics-apiserver/pull/127#issuecomment-1341493646).

`stylecheck` adds the `ST*` checks from https://staticcheck.io/docs/checks (the `SA*` and `S*` checks were already enforced).

The duplicated imports fixed in #217 would have raised an error:

```
pkg/registry/custom_metrics/reststorage.go:28:2: ST1019: package "k8s.io/apiserver/pkg/endpoints/request" is being imported more than once (stylecheck)
	"k8s.io/apiserver/pkg/endpoints/request"
	^
pkg/registry/custom_metrics/reststorage.go:29:2: ST1019(related information): other import of "k8s.io/apiserver/pkg/endpoints/request" (stylecheck)
	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
	^
pkg/registry/external_metrics/reststorage.go:26:2: ST1019: package "k8s.io/apiserver/pkg/endpoints/request" is being imported more than once (stylecheck)
	"k8s.io/apiserver/pkg/endpoints/request"
	^
pkg/registry/external_metrics/reststorage.go:27:2: ST1019(related information): other import of "k8s.io/apiserver/pkg/endpoints/request" (stylecheck)
	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
	^

```