### PR TITLE
Apply Features flags (related to pprof)

### DIFF
--- a/pkg/cmd/options/options.go
+++ b/pkg/cmd/options/options.go
@@ -95,6 +95,9 @@ func (o *CustomMetricsAdapterServerOptions) ApplyTo(serverConfig *genericapiserv
 	if err := o.Audit.ApplyTo(serverConfig); err != nil {
 		return err
 	}
+	if err := o.Features.ApplyTo(serverConfig); err != nil {
+		return err
+	}
 
 	// enable OpenAPI schemas
 	if o.OpenAPIConfig != nil {


### PR DESCRIPTION
The flags "profiling" and "contention-profiling", provided by FeatureOptions, are already added by custom-metrics-apiserver, but were not applied.
