### PR TITLE
Adds the option to disable APIServer's own metrics

### DIFF
--- a/pkg/cmd/options/options.go
+++ b/pkg/cmd/options/options.go
@@ -40,6 +40,7 @@ type CustomMetricsAdapterServerOptions struct {
 	Features       *genericoptions.FeatureOptions
 
 	OpenAPIConfig *openapicommon.Config
+	EnableMetrics bool
 }
 
 // NewCustomMetricsAdapterServerOptions creates a new instance of
@@ -51,6 +52,8 @@ func NewCustomMetricsAdapterServerOptions() *CustomMetricsAdapterServerOptions {
 		Authorization:  genericoptions.NewDelegatingAuthorizationOptions(),
 		Audit:          genericoptions.NewAuditOptions(),
 		Features:       genericoptions.NewFeatureOptions(),
+
+		EnableMetrics: true,
 	}
 
 	return o
@@ -100,6 +103,8 @@ func (o *CustomMetricsAdapterServerOptions) ApplyTo(serverConfig *genericapiserv
 	if o.OpenAPIConfig != nil {
 		serverConfig.OpenAPIConfig = o.OpenAPIConfig
 	}
+
+	serverConfig.EnableMetrics = o.EnableMetrics
 
 	return nil
 }


### PR DESCRIPTION
By setting `EnableMetrics` to false, it will be possible to disable the API server's own instrumentation metrics.
