### PR TITLE
test-adapter: add --cert-dir to manifest

### DIFF
--- a/test-adapter-deploy/testing-adapter.yaml
+++ b/test-adapter-deploy/testing-adapter.yaml
@@ -54,8 +54,8 @@ spec:
         image: REGISTRY/k8s-test-metrics-adapter-amd64:latest
         imagePullPolicy: IfNotPresent
         args:
-        - /adapter
         - --secure-port=6443
+        - --cert-dir=/var/run/serving-cert
         - --v=10
         ports:
         - containerPort: 6443
@@ -65,8 +65,14 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: temp-vol
+          readOnly: false
+        - mountPath: /var/run/serving-cert
+          name: volume-serving-cert
+          readOnly: false
       volumes:
       - name: temp-vol
+        emptyDir: {}
+      - name: volume-serving-cert
         emptyDir: {}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Adding `--cert-dir=<a temp directory>` enables the container to be executed as non-root (cf #107)

Adding it to the test-adapter should serve as an example for custom-metrics-apiserver implementations.