### PR TITLE
test-adapter: fix custom metrics on namespaces

### DIFF
--- a/test-adapter/provider/provider.go
+++ b/test-adapter/provider/provider.go
@@ -154,10 +154,6 @@ func (p *testingProvider) updateMetric(request *restful.Request, response *restf
 
 	namespace := request.PathParameter("namespace")
 	resourceType := request.PathParameter("resourceType")
-	namespaced := false
-	if len(namespace) > 0 || resourceType == "namespaces" {
-		namespaced = true
-	}
 	name := request.PathParameter("name")
 	metricName := request.PathParameter("metric")
 
@@ -187,7 +183,7 @@ func (p *testingProvider) updateMetric(request *restful.Request, response *restf
 	info := provider.CustomMetricInfo{
 		GroupResource: groupResource,
 		Metric:        metricName,
-		Namespaced:    namespaced,
+		Namespaced:    namespace != "",
 	}
 
 	info, _, err = info.Normalized(p.mapper)


### PR DESCRIPTION
There's a bug with custom metrics on namespaces in test-adapter.

To reproduce the bug:

1. Deploy the test-adapter
1. Define a metric on namespace `default`:

   ```bash
   kubectl proxy &
   curl -X POST \
     -H 'Content-Type: application/json' \
     http://localhost:8001/api/v1/namespaces/custom-metrics/services/custom-metrics-apiserver:http/proxy/write-metrics/namespaces/default/metrics/ns-metric \
     --data-raw '"300m"'
   ```
1. Check that the metric is defined:

   ```
   kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta2" | jq .
   ```
   ```json
   {
     "kind": "APIResourceList",
     "apiVersion": "v1",
     "groupVersion": "custom.metrics.k8s.io/v1beta2",
     "resources": [
       {
         "name": "namespaces/ns-metric",
         "singularName": "",
         "namespaced": true,
         "kind": "MetricValueList",
         "verbs": [
           "get"
         ]
       }
     ]
   }
   ```

1. Query the metric:

   ```
   kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta2/namespaces/default/metrics/ns-metric"
   ```
   ```
   Error from server (NotFound): the server could not find the metric ns-metric for namespaces default
   ```

With the fix, the last query gives:

```
kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta2/namespaces/default/metrics/ns-metric" | jq .
```
```json
{
  "kind": "MetricValueList",
  "apiVersion": "custom.metrics.k8s.io/v1beta2",
  "metadata": {},
  "items": [
    {
      "describedObject": {
        "kind": "Namespace",
        "name": "default",
        "apiVersion": "/v1"
      },
      "metric": {
        "name": "ns-metric",
        "selector": null
      },
      "timestamp": "2022-12-22T18:35:25Z",
      "value": "300m"
    }
  ]
}
```

(it should be noted that, with the fix, `kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta2" | jq ".resources[0].namespaced"` returns `false`.)

FYI in the REST handler, for metrics on namespaces, `namespace` is `""`:

https://github.com/kubernetes-sigs/custom-metrics-apiserver/blob/e15f12bf86a01ad500cdc1df2a1359ebbf852000/pkg/registry/custom_metrics/reststorage.go#L116-L122

Then `Namespaced` is `false`:

https://github.com/kubernetes-sigs/custom-metrics-apiserver/blob/e15f12bf86a01ad500cdc1df2a1359ebbf852000/pkg/registry/custom_metrics/reststorage.go#L149

/triage accepted
/kind bug
/assign @dgrisonnet 