### PR TITLE
Fix panic for some invalid custom metric requests

### DIFF
--- a/pkg/registry/custom_metrics/reststorage.go
+++ b/pkg/registry/custom_metrics/reststorage.go
@@ -112,15 +112,6 @@ func (r *REST) List(ctx context.Context, options *metainternalversion.ListOption
 
 	groupResource := schema.ParseGroupResource(resourceRaw)
 
-	// handle metrics describing namespaces
-	if namespace != "" && resourceRaw == "metrics" {
-		// namespace-describing metrics have a path of /namespaces/$NS/metrics/$metric,
-		groupResource = schema.GroupResource{Resource: "namespaces"}
-		metricName = name
-		name = namespace
-		namespace = ""
-	}
-
 	var res *custom_metrics.MetricValueList
 	var err error
 


### PR DESCRIPTION
Currently, the invalid custom metric request `/apis/custom.metrics.k8s.io/v1beta2/namespaces/default/foo` causes a **panic** of the adapter implementing `custom-metrics-apiserver` instead of a normal failure.

```
kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta2/namespaces/default/foo"
```

The panic is caused by the error `runtime error: slice bounds out of range [2:1]` here:

https://github.com/kubernetes-sigs/custom-metrics-apiserver/blob/e15f12bf86a01ad500cdc1df2a1359ebbf852000/pkg/apiserver/endpoints/handlers/get.go#L146

In that case, `/namespaces/default/foo` has three parts so it is handled as a **root** resource metric (`/resource/name/subresource`). However, the API server `RequestInfoResolver` handles the request as a **namespaced** resource request, and [removes the `/namespaces/default` part](https://github.com/kubernetes/apiserver/blob/92392ef22153d75b3645b0ae339f89c12767fb52/pkg/endpoints/request/requestinfo.go#L180-L190).

This commit refactors the handling of metrics related to namespaces, by moving the logic from the storage part to the handler. This allows the handler to perform validation of the request. It then rejects (with a HTTP 400 error) the problematic request.

I'll add unit tests when #139 is merged.

/kind bug
