### PR TITLE
Add support for OpenAPI v3

### DIFF
--- a/pkg/cmd/builder.go
+++ b/pkg/cmd/builder.go
@@ -26,7 +26,9 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
+	"k8s.io/apiserver/pkg/features"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
@@ -243,7 +245,7 @@ func mergeOpenAPIDefinitions(definitionsGetters []openapicommon.GetOpenAPIDefini
 	}
 }
 
-func (b *AdapterBase) defaultOpenAPIConfig() *openapicommon.Config {
+func (b *AdapterBase) openAPIConfig(createConfig func(getDefinitions openapicommon.GetOpenAPIDefinitions, defNamer *openapinamer.DefinitionNamer) *openapicommon.Config) *openapicommon.Config {
 	definitionsGetters := []openapicommon.GetOpenAPIDefinitions{generatedcore.GetOpenAPIDefinitions}
 	if b.cmProvider != nil {
 		definitionsGetters = append(definitionsGetters, generatedcustommetrics.GetOpenAPIDefinitions)
@@ -252,10 +254,18 @@ func (b *AdapterBase) defaultOpenAPIConfig() *openapicommon.Config {
 		definitionsGetters = append(definitionsGetters, generatedexternalmetrics.GetOpenAPIDefinitions)
 	}
 	getAPIDefinitions := mergeOpenAPIDefinitions(definitionsGetters)
-	openAPIConfig := genericapiserver.DefaultOpenAPIConfig(getAPIDefinitions, openapinamer.NewDefinitionNamer(apiserver.Scheme))
+	openAPIConfig := createConfig(getAPIDefinitions, openapinamer.NewDefinitionNamer(apiserver.Scheme))
 	openAPIConfig.Info.Title = b.Name
 	openAPIConfig.Info.Version = "1.0.0"
 	return openAPIConfig
+}
+
+func (b *AdapterBase) defaultOpenAPIConfig() *openapicommon.Config {
+	return b.openAPIConfig(genericapiserver.DefaultOpenAPIConfig)
+}
+
+func (b *AdapterBase) defaultOpenAPIV3Config() *openapicommon.Config {
+	return b.openAPIConfig(genericapiserver.DefaultOpenAPIV3Config)
 }
 
 // Config fetches the configuration used to ultimately create the custom metrics adapter's
@@ -274,6 +284,9 @@ func (b *AdapterBase) Config() (*apiserver.Config, error) {
 			b.OpenAPIConfig = b.defaultOpenAPIConfig()
 		}
 		b.CustomMetricsAdapterServerOptions.OpenAPIConfig = b.OpenAPIConfig
+		if b.OpenAPIV3Config == nil && utilfeature.DefaultFeatureGate.Enabled(features.OpenAPIV3) {
+			b.OpenAPIV3Config = b.defaultOpenAPIV3Config()
+		}
 
 		if errList := b.CustomMetricsAdapterServerOptions.Validate(); len(errList) > 0 {
 			return nil, utilerrors.NewAggregate(errList)

--- a/pkg/cmd/options/options.go
+++ b/pkg/cmd/options/options.go
@@ -39,8 +39,9 @@ type CustomMetricsAdapterServerOptions struct {
 	Audit          *genericoptions.AuditOptions
 	Features       *genericoptions.FeatureOptions
 
-	OpenAPIConfig *openapicommon.Config
-	EnableMetrics bool
+	OpenAPIConfig   *openapicommon.Config
+	OpenAPIV3Config *openapicommon.Config
+	EnableMetrics   bool
 }
 
 // NewCustomMetricsAdapterServerOptions creates a new instance of
@@ -105,6 +106,9 @@ func (o *CustomMetricsAdapterServerOptions) ApplyTo(serverConfig *genericapiserv
 	// enable OpenAPI schemas
 	if o.OpenAPIConfig != nil {
 		serverConfig.OpenAPIConfig = o.OpenAPIConfig
+	}
+	if o.OpenAPIV3Config != nil {
+		serverConfig.OpenAPIV3Config = o.OpenAPIV3Config
 	}
 
 	serverConfig.EnableMetrics = o.EnableMetrics


### PR DESCRIPTION
Add support for OpenAPI v3

Cf the [implementation in sample-apiserver](https://github.com/kubernetes/kubernetes/blob/3f05d41a416433f3ff90a94edea1f4f876faf132/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go#L144-L148)

/kind feature