### PR TITLE
resClient.List add resourceVersion=0 parameter

### DIFF
--- a/pkg/provider/helpers/helpers.go
+++ b/pkg/provider/helpers/helpers.go
@@ -84,7 +84,7 @@ func ListObjectNames(mapper apimeta.RESTMapper, client dynamic.Interface, namesp
 		resClient = client.Resource(res)
 	}
 
-	matchingObjectsRaw, err := resClient.List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	matchingObjectsRaw, err := resClient.List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String(), ResourceVersion: "0"})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fix: #154 
resourceVersion=0 is not specified here, causing apiserver to skip the cache and go directly to etcd to read the data.
add resourceVersion=0 parameter, apiserver will read data from the cache, and there is an order of magnitude performance improvement.