### PR TITLE
Disable priority and fairness by default

### DIFF
--- a/pkg/cmd/options/options.go
+++ b/pkg/cmd/options/options.go
@@ -58,6 +58,10 @@ func NewCustomMetricsAdapterServerOptions() *CustomMetricsAdapterServerOptions {
 		EnableMetrics: true,
 	}
 
+	// Explicitly disable Priority and Fairness since metric servers are not
+	// meant to be queried directly by default.
+	o.Features.EnablePriorityAndFairness = false
+
 	return o
 }
 

--- a/test-adapter-deploy/testing-adapter.yaml
+++ b/test-adapter-deploy/testing-adapter.yaml
@@ -176,14 +176,6 @@ rules:
   verbs:
   - get
   - list
-- apiGroups:
-  - flowcontrol.apiserver.k8s.io
-  resources:
-  - prioritylevelconfigurations
-  - flowschemas
-  verbs:
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Disable priority and fairness by default because the metric APIs are not meant to be interacted with directly but rather by going through the kube-apiserver where the P&F config should reside. In the eventually that some users ever need to enable P&F at the metric server level, they will still be able to do it via the `--enable-priority-and-fairness` flag.