### PR TITLE
chore: bump go to 1.24.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,10 +5,10 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    - copyloopvar
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
     - gocritic
     - gocyclo
     - gofmt

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOPATH:=$(shell go env GOPATH)
 
 VERSION?=latest
 
-GOLANGCI_VERSION:=1.63.4
+GOLANGCI_VERSION:=1.64.8
 
 .PHONY: all
 all: build-test-adapter

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module sigs.k8s.io/custom-metrics-apiserver
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.6
+toolchain go1.24.2
 
 require (
 	github.com/emicklei/go-restful/v3 v3.12.1


### PR DESCRIPTION
Update golangci-lint to a version built with golang 1.24.

The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since
Go1.22 (loopvar) this linter is no longer relevant. Replaced by
copyloopvar.