### PR TITLE
ONWERS: add RainbowMango

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,6 @@
 approvers:
 - dgrisonnet
+- RainbowMango
 reviewers:
 - dgrisonnet
-- olivierlemasle
+- RainbowMango


### PR DESCRIPTION
Based on the discussion I had on Slack with @richabanker and @rexagod, we agreed that the project needs more care and it would be in everyone's best interest to empower some of its main consumers to keep the project up-to-date.

To achieve that goal I updated the OWNERS file and added @RainbowMango (Kamarda) as an approver.