### PR TITLE
Bump Golang version to v1.25.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOPATH:=$(shell go env GOPATH)
 
 VERSION?=latest
 
-GOLANGCI_VERSION:=2.1.6
+GOLANGCI_VERSION:=2.8.0
 
 .PHONY: all
 all: build-test-adapter

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module sigs.k8s.io/custom-metrics-apiserver
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.4
+toolchain go1.25.6
 
 require (
 	github.com/emicklei/go-restful/v3 v3.13.0


### PR DESCRIPTION
This PR bumps Golang to v1.25.0 as it is necessary before bumping Kubernetes v1.35. 
See https://github.com/kubernetes-sigs/custom-metrics-apiserver/pull/224#issuecomment-3707525493 for reference.