### PR TITLE
Bump Golang to v1.26.4 and golangci-lint.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ HAS_GOLANGCI_VERSION:=$(shell $(GOPATH)/bin/golangci-lint version --short)
 .PHONY: golangci
 golangci:
 ifneq ($(HAS_GOLANGCI_VERSION), $(GOLANGCI_VERSION))
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v$(GOLANGCI_VERSION)
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOPATH)/bin v$(GOLANGCI_VERSION)
 endif
 
 .PHONY: verify-lint

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOPATH:=$(shell go env GOPATH)
 
 VERSION?=latest
 
-GOLANGCI_VERSION:=2.8.0
+GOLANGCI_VERSION:=2.12.2
 
 .PHONY: all
 all: build-test-adapter

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module sigs.k8s.io/custom-metrics-apiserver
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.6
+toolchain go1.26.4
 
 require (
 	github.com/emicklei/go-restful/v3 v3.13.0

--- a/pkg/apiserver/installer/installer.go
+++ b/pkg/apiserver/installer/installer.go
@@ -199,7 +199,7 @@ func addObjectParams(ws *restful.WebService, route *restful.RouteBuilder, obj in
 			}
 			switch sf.Type.Kind() {
 			case reflect.Interface, reflect.Struct:
-			case reflect.Ptr:
+			case reflect.Pointer:
 				// TODO: This is a hack to let metav1.Time through. This needs to be fixed in a more generic way eventually. bug #36191
 				if (sf.Type.Elem().Kind() == reflect.Interface || sf.Type.Elem().Kind() == reflect.Struct) && strings.TrimPrefix(sf.Type.String(), "*") != "metav1.Time" {
 					continue


### PR DESCRIPTION
 It is required to bump Kubernetes dependencies.

Refer: https://github.com/kubernetes-sigs/custom-metrics-apiserver/pull/236#issuecomment-4331689984