### PR TITLE
Publish delegated authentication security definitions to the OpenAPI config

### DIFF
--- a/pkg/cmd/options/options.go
+++ b/pkg/cmd/options/options.go
@@ -95,7 +95,7 @@ func (o *CustomMetricsAdapterServerOptions) ApplyTo(serverConfig *genericapiserv
 	if err := o.SecureServing.ApplyTo(&serverConfig.SecureServing, &serverConfig.LoopbackClientConfig); err != nil {
 		return err
 	}
-	if err := o.Authentication.ApplyTo(&serverConfig.Authentication, serverConfig.SecureServing, nil); err != nil {
+	if err := o.Authentication.ApplyTo(&serverConfig.Authentication, serverConfig.SecureServing, o.OpenAPIConfig); err != nil {
 		return err
 	}
 	if err := o.Authorization.ApplyTo(&serverConfig.Authorization); err != nil {

--- a/pkg/cmd/options/options_test.go
+++ b/pkg/cmd/options/options_test.go
@@ -17,15 +17,19 @@ limitations under the License.
 package options
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/rest"
+	openapicommon "k8s.io/kube-openapi/pkg/common"
 
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver"
 )
@@ -129,4 +133,42 @@ func TestApplyTo(t *testing.T) {
 			assert.NoErrorf(t, err, "Error while applying options")
 		})
 	}
+}
+
+func TestApplyToOpenAPISecurityDefinitions(t *testing.T) {
+	// A kubeconfig is enough to get a token review client, which is what makes
+	// the delegating authenticator publish its BearerToken security scheme.
+	kubeconfig := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(kubeconfig, []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster: {server: https://127.0.0.1:6443}
+  name: test
+contexts:
+- context: {cluster: test, user: test}
+  name: test
+current-context: test
+users:
+- name: test
+  user: {token: test}
+`), 0600))
+
+	o := NewCustomMetricsAdapterServerOptions()
+	o.Authentication.RemoteKubeConfigFile = kubeconfig
+	o.Authentication.SkipInClusterLookup = true
+	o.Authorization.RemoteKubeConfigFileOptional = true
+	o.OpenAPIConfig = &openapicommon.Config{}
+
+	flagSet := pflag.NewFlagSet("", pflag.PanicOnError)
+	o.AddFlags(flagSet)
+	require.NoError(t, flagSet.Parse([]string{"--secure-port=0"}))
+
+	serverConfig := genericapiserver.NewRecommendedConfig(apiserver.Codecs)
+	serverConfig.ClientConfig = &rest.Config{}
+	serverConfig.SharedInformerFactory = informers.NewSharedInformerFactory(nil, 0)
+	require.NoError(t, o.ApplyTo(serverConfig))
+
+	require.NotNil(t, o.OpenAPIConfig.SecurityDefinitions, "security definitions were not published to the OpenAPI config")
+	assert.Contains(t, *o.OpenAPIConfig.SecurityDefinitions, "BearerToken")
+	assert.Same(t, o.OpenAPIConfig, serverConfig.OpenAPIConfig)
 }


### PR DESCRIPTION
`ApplyTo` hands a literal `nil` to `DelegatingAuthenticationOptions.ApplyTo` as the `openAPIConfig` argument:

```go
if err := o.Authentication.ApplyTo(&serverConfig.Authentication, serverConfig.SecureServing, nil); err != nil {
```

Upstream only copies the security definitions when that argument is non-nil (`authentication.go`):

```go
authenticator, securityDefinitions, err := cfg.New()
...
if openAPIConfig != nil {
    openAPIConfig.SecurityDefinitions = securityDefinitions
}
```

so the `BearerToken` scheme the delegating authenticator builds is dropped on the floor and the served OpenAPI spec has no `securityDefinitions`. The generic apiserver's own `RecommendedOptions.ApplyTo` passes `config.OpenAPIConfig` in this spot, so adapters built on this repo end up with a spec that differs from every other aggregated apiserver. Clients and codegen that read the spec to discover the auth scheme see nothing.

One note on the fix: it passes `o.OpenAPIConfig`, not `serverConfig.OpenAPIConfig`. `serverConfig.OpenAPIConfig` is only assigned about twenty lines further down in the same function, so it is still nil at the call site and using it would leave the behavior exactly as it is now. I checked that, and the test below fails with either `nil` or `serverConfig.OpenAPIConfig`. Since the two point at the same `Config` once the assignment happens, the definitions land on the config the server actually serves.

Test added to `pkg/cmd/options/options_test.go`. It needs a kubeconfig because the `BearerToken` scheme is only emitted when a token review client exists.

Fails before:

```
--- FAIL: TestApplyToOpenAPISecurityDefinitions (0.00s)
    options_test.go:171:
        	Error:      	Expected value not to be nil.
        	Messages:   	security definitions were not published to the OpenAPI config
FAIL
```

Passes after, and the rest of the suite is unaffected:

```
$ go build ./...
$ go test ./...
ok  	sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/installer	1.473s
ok  	sigs.k8s.io/custom-metrics-apiserver/pkg/apiserver/metrics	0.559s
ok  	sigs.k8s.io/custom-metrics-apiserver/pkg/cmd	(cached)
ok  	sigs.k8s.io/custom-metrics-apiserver/pkg/cmd/options	2.308s
ok  	sigs.k8s.io/custom-metrics-apiserver/pkg/dynamicmapper	3.250s
ok  	sigs.k8s.io/custom-metrics-apiserver/pkg/provider	2.644s
```

Happy to drop the `assert.Same` line if it reads as over-specified.
